### PR TITLE
refactored to handle custom_pivot endpoints https://www.aha.io/api/re…

### DIFF
--- a/ahapy/__init__.py
+++ b/ahapy/__init__.py
@@ -106,7 +106,6 @@ class AhaV1(BaseAPI):
                 # so we need to give it special handling
                 result = r.copy()
                 if 'pagination' in result:
-                    print(result['pagination'])
                     del result['pagination']
                     yield result
 

--- a/ahapy/__init__.py
+++ b/ahapy/__init__.py
@@ -4,7 +4,7 @@ import re
 
 class BaseAPI(object):
     def __init__(self, sub_domain, api_key):
-        self.sub_domain = sub_domain 
+        self.sub_domain = sub_domain
         self.api_key = api_key
 
         self.url = 'https://{}.aha.io/api'.format(self.sub_domain)
@@ -13,10 +13,9 @@ class BaseAPI(object):
         self.session.headers.update({'Authorization': 'Bearer ' + api_key})
 
 
-
 class AhaV1(BaseAPI):
     def __init__(self, sub_domain, api_key):
-        self.sub_domain = sub_domain 
+        self.sub_domain = sub_domain
         self.api_key = api_key
         self.version = '/v1/'
         self.page = 1
@@ -26,14 +25,12 @@ class AhaV1(BaseAPI):
 
         super(AhaV1, self).__init__(sub_domain, api_key)
 
-
     def _count(self, endpoint, **options):
         url = self.url + self.version + endpoint
         response = self.session.get(url, params=options)
         r = response.json()
         self.count = r['pagination']['total_records']
         return self.count
-    
 
     def _parse_endpoint_arg(self, endpoint_arg):
         s = re.split('/', endpoint_arg)
@@ -42,12 +39,29 @@ class AhaV1(BaseAPI):
         else:
             return s[-2]
 
+    def _pagination(self, json_response):
+        """
+        Extracts pagination information from a JSON response dictionary.
 
-    def _is_paginated(self, json_response):
-        if 'pagination' in json_response.keys():
-            return True
+        Parameters:
+            json_response (dict): A dictionary containing the JSON response data.
+
+        Returns:
+            The first element of the 'pagination' list in the json_response dictionary,
+            if it exists. If 'pagination' is not a list, it is returned as-is. If 'pagination'
+            does not exist in the json_response dictionary, None is returned.
+        """
+        if 'pagination' in json_response:
+            pagination = json_response['pagination']
+            if isinstance(pagination, list):
+                if len(pagination) > 0:
+                    return pagination[0]
+                else:
+                    return None
+            else:
+                return pagination
         else:
-            return False
+            return None
 
 
     def query(self, endpoint, **options):
@@ -64,20 +78,22 @@ class AhaV1(BaseAPI):
             else:
                 response = self.session.get(url, params=options)
                 r = response.json()
-                if self._is_paginated(r):
-                    self.count = r['pagination']['total_records']
+                pagination = self._pagination(r)
+                if pagination is not None:
+                    self.count = pagination['total_records']
 
             if not response.ok:
                 print("Response status code: " + str(response.status_code))
                 print("Response text: " + response.text)
-            
+
             r = response.json()
-            if self._is_paginated(r):
-                self.total_pages = r['pagination']['total_pages']
-                self.page = r['pagination']['current_page'] + 1
+            pagination = self._pagination(r)
+            if pagination is not None:
+                self.total_pages = pagination['total_pages']
+                self.page = pagination['current_page'] + 1
             else:
                 # trim pluralization from endpoint as this is 
-                # singluar in response body if no pagination
+                # singular in response body if no pagination
                 # this is used as a check later to make sure 
                 # response body matches expectations
                 self.endpoint = self.endpoint[:-1]
@@ -85,6 +101,14 @@ class AhaV1(BaseAPI):
             if self.endpoint in r.keys():
                 for i in r[self.endpoint]:
                     yield i
-            
+            elif self.endpoint == 'custom_pivots':
+                # custom_pivots response does not follow the same pattern as the other endpoints
+                # so we need to give it special handling
+                result = r.copy()
+                if 'pagination' in result:
+                    print(result['pagination'])
+                    del result['pagination']
+                    yield result
+
             if self.page > self.total_pages:
                 break

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -9,60 +9,96 @@ from ahapy import AhaV1
 # python -m unittest
 
 AHA_KEY = os.environ.get('AHA_API_KEY')
+assert AHA_KEY is not None, "Set AHA_API_KEY environment variable"
+
+AHAPY_TEST_SUBDOMAIN = os.environ.get("AHAPY_TEST_SUBDOMAIN")
+assert AHAPY_TEST_SUBDOMAIN is not None, "Set AHAPY_TEST_SUBDOMAIN environment variable"
+
 
 class TestClient(unittest.TestCase):
 
     def test_v1_query(self):
-        aha = AhaV1('enverus', AHA_KEY)
+        aha = AhaV1(AHAPY_TEST_SUBDOMAIN, AHA_KEY)
         data = aha.query('initiatives')
         self.assertIsNotNone(data)
 
 
     def test_v1_count(self):
-        aha = AhaV1('enverus', AHA_KEY)
+        aha = AhaV1(AHAPY_TEST_SUBDOMAIN, AHA_KEY)
         count = aha._count('epics')
         self.assertGreater(count, -1)
 
 
     def test_v1_fields(self):
-        aha = AhaV1('enverus', AHA_KEY)
+        aha = AhaV1(AHAPY_TEST_SUBDOMAIN, AHA_KEY)
         data = aha.query('initiatives', fields='name,id')
         for i in data:
             self.assertIsNotNone(i['name'])
 
 
     def test_v1_page(self):
-        aha = AhaV1('enverus', AHA_KEY)
+        aha = AhaV1(AHAPY_TEST_SUBDOMAIN, AHA_KEY)
         aha.query('initiatives', per_page=200)
         expected_pages = math.ceil(aha.count / 200)
         self.assertEqual(expected_pages, aha.total_pages)
 
 
     def test_v1_endpoint_parse_1(self):
-        aha = AhaV1('enverus', AHA_KEY)
+        aha = AhaV1(AHAPY_TEST_SUBDOMAIN, AHA_KEY)
         endpoint = aha._parse_endpoint_arg('initiatives/12345/epics')
         self.assertEqual('epics', endpoint)
 
 
     def test_v1_endpoint_parse_2(self):
-        aha = AhaV1('enverus', AHA_KEY)
+        aha = AhaV1(AHAPY_TEST_SUBDOMAIN, AHA_KEY)
         endpoint = aha._parse_endpoint_arg('initiatives/12345')
         self.assertEqual('initiatives', endpoint)
 
 
     def test_v1_endpoint_parse_3(self):
-        aha = AhaV1('enverus', AHA_KEY)
+        aha = AhaV1(AHAPY_TEST_SUBDOMAIN, AHA_KEY)
         endpoint = aha._parse_endpoint_arg('initiatives')
         self.assertEqual('initiatives', endpoint)
 
+    def test_v1_endpoint_parse_4(self):
+        aha = AhaV1(AHAPY_TEST_SUBDOMAIN, AHA_KEY)
+        endpoint = aha._parse_endpoint_arg('bookmarks/custom_pivots/801750833?view=list')
+        self.assertEqual('custom_pivots', endpoint)
 
-    def test_v1_is_paginated_true(self):
-        aha = AhaV1('enverus', AHA_KEY)
-        mock = {"pagination":"yes"}
-        self.assertTrue(aha._is_paginated(mock))
-    
+    def test_v1_custom_pivot_list(self):
+        aha = AhaV1(AHAPY_TEST_SUBDOMAIN, AHA_KEY)
+        data = aha.query('bookmarks/custom_pivots/7216017113000441776', view='list')
+        required_keys = ['columns','rows']
+        for row in data:
+            existing_keys = list((key in row for key in required_keys))
+            self.assertTrue(all(existing_keys),
+                            f"Missing keys: {[required_keys[i] for i,exist in enumerate(existing_keys) if not exist]}")
+            break
 
-    def test_v1_is_paginated_false(self):
-        aha = AhaV1('enverus', AHA_KEY)
-        mock = {"no_pagination":"no"}
-        self.assertFalse(aha._is_paginated(mock))
+    def test_pagination_with_list(self):
+        # Test that it returns the first element of a non-empty pagination list
+        aha = AhaV1(AHAPY_TEST_SUBDOMAIN, AHA_KEY)
+        json_response = {'pagination': [{'page': 1, 'total_pages': 5}]}
+        result = aha._pagination(json_response)
+        self.assertEqual(result, {'page': 1, 'total_pages': 5})
+
+    def test_pagination_with_non_list(self):
+        # Test that it returns a non-list object as is
+        aha = AhaV1(AHAPY_TEST_SUBDOMAIN, AHA_KEY)
+        json_response = {'pagination': {'page': 1, 'total_pages': 5}}
+        result = aha._pagination(json_response)
+        self.assertEqual(result, {'page': 1, 'total_pages': 5})
+
+    def test_pagination_missing(self):
+        # Test that it returns None if pagination is missing
+        aha = AhaV1(AHAPY_TEST_SUBDOMAIN, AHA_KEY)
+        json_response = {'data': [1, 2, 3]}
+        result = aha._pagination(json_response)
+        self.assertIsNone(result)
+
+    def test_pagination_with_empty_list(self):
+        # Test that it returns None if pagination list is empty
+        aha = AhaV1(AHAPY_TEST_SUBDOMAIN, AHA_KEY)
+        json_response = {'pagination': []}
+        result = aha._pagination(json_response)
+        self.assertIsNone(result)


### PR DESCRIPTION
…sources/custom_pivots/get_the_list_view_of_a_saved_report  .  They do not return a payload with the same pattern as most other resources in this API.

Changed the test code to reference environment variables instead of hardcoded Aha subdomain.  Added assertions at the top of the test file to give better messages to the user about which environment variables are missing.